### PR TITLE
Fix crash on iOS14

### DIFF
--- a/Classes/UIMultiPicker.swift
+++ b/Classes/UIMultiPicker.swift
@@ -156,7 +156,8 @@ class TableViewProxy: NSObject, UITableViewDataSource
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = dataSource.tableView(tableView, cellForRowAt: indexPath)
-        let label = cell.subviews[1] as! UILabel
+        let label = cell.subviews.first(where: { (temp) -> Bool in
+            return temp is UILabel}) as! UILabel
 
         let tap = cell.gestureRecognizers![0] as! UITapGestureRecognizer
         cell.tag = indexPath.row


### PR DESCRIPTION
This fixes the following crash for me in my app and the UIMultiPicker Demo App when running on my iOS 14.3 device.

Could not cast value of type 'UITableViewCellContentView' (0x20a466d90) to 'UILabel' (0x20a46b390).
2020-12-22 11:41:06.643225-0700 UIMultiPickerDemo[1764:1030773] Could not cast value of type 'UITableViewCellContentView' (0x20a466d90) to 'UILabel' (0x20a46b390).